### PR TITLE
Adding code to run detection on Canadian roosts data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ debug.env
 
 # .lock
 *.lock
+
+# default inference results folder
+inference_results

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,8 @@ install_requires = [
     "gdown==4.4.0",             # 4.4.0
     ### data ###
     "awscli",
+    "azure-storage-blob==12.16.0",
+    "h5py==3.9.0",             # time zone, 2021.1
     "pytz==2021.1",             # time zone, 2021.1
     "ephem==3.7.7.1",           # 3.7.7.1
     "geopy==2.1.0",             # 2.1.0

--- a/src/roosts/data/downloader/__init__.py
+++ b/src/roosts/data/downloader/__init__.py
@@ -1,0 +1,3 @@
+from .downloader import Downloader
+from .downloader_america import DownloaderAmerica
+from .downloader_canada import DownloaderCanada

--- a/src/roosts/data/downloader/downloader.py
+++ b/src/roosts/data/downloader/downloader.py
@@ -1,0 +1,18 @@
+import os
+from roosts.utils.s3_util import download_scan
+from tqdm import tqdm
+from abc import ABC, abstractmethod
+
+class Downloader(ABC):
+
+    """ 
+        Base class for download from Azure, AWS:
+        iteratively downloads the radar scans in a certain date range from a
+        certain radar station in a daily basis. Station-day is the minimum unit of
+        tracking roosts.
+    """
+
+    @abstractmethod
+    def download_scans(self, keys, logger):
+        """ Download radar scans from AWS/Azure """
+        pass

--- a/src/roosts/data/downloader/downloader_america.py
+++ b/src/roosts/data/downloader/downloader_america.py
@@ -1,13 +1,14 @@
 import os
 from roosts.utils.s3_util import download_scan
 from tqdm import tqdm
+from .downloader import Downloader
 
-
-class Downloader:
+class DownloaderAmerica(Downloader):
 
     """ 
-        This class iteratively downloads the radar scans in a certain date range from a certain radar station
-        in a daily basis. Station-day is the minimum unit of tracking roosts.
+        This class iteratively downloads the radar scans in a certain date range from a
+        certain radar station in a daily basis from AWS. Station-day is the minimum unit of
+        tracking roosts.
     """
 
     def __init__(self, download_dir, npz_dir, aws_access_key_id=None, aws_secret_access_key=None):

--- a/src/roosts/data/downloader/downloader_canada.py
+++ b/src/roosts/data/downloader/downloader_canada.py
@@ -1,0 +1,61 @@
+import os
+from roosts.utils.azure_sa_util import download_scan
+from tqdm import tqdm
+from .downloader import Downloader
+
+class DownloaderCanada(Downloader):
+
+    """ 
+        This class iteratively downloads the radar scans in a certain date range from a
+        certain radar station in a daily basis from Azure. Station-day is the minimum unit of
+        tracking roosts.
+    """
+
+    def __init__(self, download_dir, npz_dir):
+        self.download_dir = download_dir
+        os.makedirs(self.download_dir, exist_ok=True)
+        self.npz_dir = npz_dir
+
+    def get_file_download_loc(self, key):
+        """ For each key, obtain the location for download, 
+            to match American data download locations
+        Eg: canadian file key = '2022060109_18_ODIMH5_PVOL6S_VOL_CASET.h5'
+        output = 2022/06/01/CSET/CSET20220601_091800
+        """
+        utc_year = key[:4]
+        utc_month = key[4:6]
+        utc_date = key[6:8]
+        utc_station = "CSET" # Hardcoded value
+        utc_hour = key[8:10]
+        utc_min = key[11:13]
+        utc_sec = '00' # Hardcoded as seconds information not present for Canadian data
+        filename = f"{utc_station}{utc_year}{utc_month}{utc_date}_{utc_hour}{utc_min}{utc_sec}"
+        return f"{utc_year}/{utc_month}/{utc_date}/{utc_station}/{filename}"
+        
+
+    def download_scans(self, keys, logger):
+        """ Download radar scans from Azure """
+
+        valid_keys = [] # list of the file path of downloaded scans
+        for key in tqdm(keys, desc="Downloading"):
+
+            file_download_loc = self.get_file_download_loc(key)
+            file_download_name = file_download_loc.split("/")[-1]
+            # skip if an npz file is already rendered
+            if os.path.exists(os.path.join(self.npz_dir, f"{file_download_loc}.npz")):
+                valid_keys.append(file_download_loc)
+                continue
+
+            try:
+                download_scan(
+                    key,
+                    self.download_dir,
+                    file_download_loc
+                )
+                valid_keys.append(file_download_loc)
+                logger.info('[Download Success] scan %s' % file_download_name)
+            except Exception as ex:
+                logger.error('[Download Failure] scan %s - %s' % (file_download_name, str(ex)))
+
+        return valid_keys
+

--- a/src/roosts/data/renderer.py
+++ b/src/roosts/data/renderer.py
@@ -65,6 +65,16 @@ NORMALIZERS = {
     'cross_correlation_ratio':      pltc.Normalize(vmin=   0, vmax= 1.1)
 }
 
+ODIM_FIELD_NAMES = {
+    'DBZH' : 'reflectivity',
+    'TH': 'total_power',
+    'RHOHV': 'cross_correlation_ratio',
+    'WRADH': 'spectrum_width',
+    'PHIDP': 'differential_phase',
+    'ZDR': 'differential_reflectivity',
+    'KDP': 'specific_differential_phase',
+    'VRADH': 'velocity'
+}
 
 class Renderer:
     def __init__(
@@ -74,6 +84,7 @@ class Renderer:
             ui_img_dir,
             array_render_config=ARRAY_RENDER_CONFIG,
             dualpol_render_config=DUALPOL_RENDER_CONFIG,
+            is_canadian_data=False
     ):
         self.download_dir = download_dir
         self.npz_dir = npz_dir
@@ -84,6 +95,7 @@ class Renderer:
 
         self.array_render_config = array_render_config
         self.dualpol_render_config = dualpol_render_config
+        self.is_canadian_data = is_canadian_data
 
     def render(self, keys, logger, force_rendering=False):
         """
@@ -124,7 +136,11 @@ class Renderer:
             arrays = {}
 
             try:
-                radar = pyart.io.read_nexrad_archive(os.path.join(self.download_dir, key))
+                if self.is_canadian_data:
+                    radar = pyart.aux_io.read_odim_h5(os.path.join(self.download_dir, key),
+                                                      field_names=ODIM_FIELD_NAMES)
+                else:
+                    radar = pyart.io.read_nexrad_archive(os.path.join(self.download_dir, key))
             except Exception as ex:
                 logger.error('[Scan Loading Failure] scan %s - %s' % (scan, str(ex)))
                 continue

--- a/src/roosts/system.py
+++ b/src/roosts/system.py
@@ -2,7 +2,7 @@ import copy
 import logging
 import os
 import time
-from roosts.data.downloader import Downloader
+from roosts.data.downloader import DownloaderAmerica, DownloaderCanada
 from roosts.data.renderer import Renderer
 from roosts.detection.detector import Detector
 from roosts.tracking.tracker import Tracker
@@ -17,12 +17,23 @@ class RoostSystem:
     def __init__(self, args, det_cfg, pp_cfg, dirs):
         self.args = args
         self.dirs = dirs
-        self.downloader = Downloader(
-            download_dir=dirs["scan_dir"], npz_dir=dirs["npz_dir"],
-            aws_access_key_id=args.aws_access_key_id,
-            aws_secret_access_key=args.aws_secret_access_key,
-        )
-        self.renderer = Renderer(dirs["scan_dir"], dirs["npz_dir"], dirs["ui_img_dir"])
+        
+        if 'is_canadian' not in args or not args.is_canadian:
+            self.is_canadian_data = False
+            self.downloader = DownloaderAmerica(
+                download_dir=dirs["scan_dir"], npz_dir=dirs["npz_dir"],
+                aws_access_key_id=args.aws_access_key_id,
+                aws_secret_access_key=args.aws_secret_access_key
+            )
+        else:
+            self.is_canadian_data = True
+            self.downloader = DownloaderCanada(
+                download_dir=dirs["scan_dir"],
+                npz_dir=dirs["npz_dir"]
+            )
+
+        self.renderer = Renderer(dirs["scan_dir"], dirs["npz_dir"], dirs["ui_img_dir"],
+                                 is_canadian_data=self.is_canadian_data)
         if not args.just_render:
             self.detector = Detector(**det_cfg)
             self.tracker = Tracker()
@@ -33,7 +44,7 @@ class RoostSystem:
             self,
             day, # timestamps that indicate the beginning of dates, no time zone info
             sun_activity_time, # utc timestamp for the next local sun activity after the beginning of the local date
-            keys, # aws keys which uses UTC time: yyyy/mm/dd/ssss/ssssyyyymmdd_hhmmss*
+            keys, # aws/azure keys which uses UTC time: yyyy/mm/dd/ssss/ssssyyyymmdd_hhmmss*
             process_start_time
     ):
         local_date_string = day.strftime('%Y%m%d')  # yyyymmdd

--- a/src/roosts/utils/azure_sa_util.py
+++ b/src/roosts/utils/azure_sa_util.py
@@ -1,0 +1,127 @@
+from datetime import datetime, timedelta
+import re
+import os
+import pytz
+from azure.storage.blob import ContainerClient
+
+####################################
+# Helpers
+####################################
+def datetime_range(start=None, end=None, delta=timedelta(minutes=1), inclusive=True):
+    """Construct a generator for a range of dates
+    
+    Args:
+        start (datetime): start time
+        end (datetime): end time
+        delta (timedelta): time increment
+        inclusive (bool): whether to include the end date
+    
+    Returns:
+        Generator object
+    """
+    t = start or datetime.now()
+    
+    if inclusive:
+        keep_going = lambda s, e: s <= e
+    else:
+        keep_going = lambda s, e: s < e
+
+    while keep_going(t, end):
+        yield t
+        t = t + delta
+    return
+
+
+def blob_date_prefix(t):
+    """Construct prefix of h5 file containing only its year, month and date
+
+    Args:
+        t (datetime): timestamp of file
+
+    Returns:
+        string: blob prefix contain date information
+        
+    Example format:
+            blob name: 2022060100_06_ODIMH5_PVOL6S_VOL_CASET.h5
+        return val: 20220601
+    """
+    prefix = '%04d%02d%02d' % (t.year, t.month, t.day)
+    return prefix
+
+def obtain_blob_timestamp(key):
+    _, key = os.path.split(key)
+    vals = re.match('(\d{4}\d{2}\d{2}\d{2}_\d{2})(\.?\w+)', key)
+    (timestamp, suffix) = vals.groups()
+    t = datetime.strptime(timestamp, '%Y%m%d%H_%M')
+    return pytz.utc.localize(t)
+
+
+####################################
+# Azure setup
+####################################
+
+def get_station_day_scan_keys(
+        start_time,
+        end_time,
+        station, # not being used right now
+        stride_in_minutes=6,
+        thresh_in_minutes=6
+):
+
+
+    container_client = ContainerClient(
+            account_url="https://roostcanada.blob.core.windows.net",
+            container_name="caset-2022",
+            credential=None)
+   
+    blob_names = []
+    current_time = start_time
+    # This loop usually runs only once, but we put it in the while loop
+    # in case utc times for a day span across dates
+    while current_time <= end_time:
+        date_prefix = blob_date_prefix(current_time)
+        blob_names.extend(list(container_client.list_blob_names(name_starts_with=date_prefix)))
+        current_time = current_time + timedelta(days=1)
+
+    if not blob_names:
+        return []
+
+    # # iterate by time and select the appropriate scans
+    times = list(datetime_range(start_time, end_time, timedelta(minutes=stride_in_minutes)))
+    time_thresh = timedelta(minutes=thresh_in_minutes)
+
+    selected_blob_names = []
+    current_idx = 0
+    for t in times:
+        t_current = obtain_blob_timestamp(blob_names[current_idx])
+
+        while current_idx + 1 < len(blob_names):
+            t_next = obtain_blob_timestamp(blob_names[current_idx + 1])
+            if abs(t_current - t) < abs(t_next - t):
+                break
+            t_current = t_next
+            current_idx += 1
+
+        if abs(t_current - t) <= time_thresh:
+            selected_blob_names.append(blob_names[current_idx])
+
+    return selected_blob_names
+
+
+def download_scan(
+        key,
+        data_dir,
+        file_download_loc):
+
+    container_client = ContainerClient(
+            account_url="https://roostcanada.blob.core.windows.net",
+            container_name="caset-2022",
+            credential=None)
+    
+    local_file = os.path.join(data_dir, file_download_loc)
+    local_dir, filename = os.path.split(local_file)
+    os.makedirs(local_dir, exist_ok=True)
+
+    if not os.path.isfile(local_file):
+        with open(file=local_file, mode="wb") as f:
+            f.write(container_client.download_blob(key).readall())

--- a/src/roosts/utils/nexrad_util.py
+++ b/src/roosts/utils/nexrad_util.py
@@ -163,6 +163,12 @@ NEXRAD_LOCATIONS = {
     "RKSG": {'lat': 36.95972,  'lon': 127.01833,   'elev': 52,     'tz': 'Asia/Seoul'},
     "RODN": {'lat': 26.30194,  'lon': 127.90972,   'elev': 218,    'tz': 'Asia/Tokyo'},
     "TJUA": {'lat': 18.1175,   'lon': -66.07861,   'elev': 2794,   'tz': 'America/Puerto_Rico'},
+    # Canadian station EXETER - added for consistency, not a NEXRAD station
+    # Sources - 
+    # 1. https://en.wikipedia.org/wiki/Canadian_weather_radar_network, 
+    # 2. TODO: Confirm elevation. Currently found from - https://www.freemaptools.com/elevation-finder.htm
+    # 3. timezone = EDT (https://www.timetemperature.com/tzon/exeter.shtml)
+    "CSET": {'lat': 43.37243,   'lon': -81.3807,   'elev': 997,   'tz': 'America/New_York'}
 }
 
 # Regions Dictionary, To Be Filled with list of stations by region.

--- a/src/roosts/utils/time_util.py
+++ b/src/roosts/utils/time_util.py
@@ -48,6 +48,7 @@ def get_sun_activity_time(
 
     # Taken from the refernce link
     # To get U.S. Naval Astronomical Almanac values, use these settings
+    # Using the same definition of sunrise and sunset for Canadian data
     obs.pressure = 0
     obs.horizon = '-0:34'
 

--- a/tools/launch_demo_without_slurm_america.py
+++ b/tools/launch_demo_without_slurm_america.py
@@ -1,0 +1,92 @@
+import time, os, torch, warnings
+from datetime import timedelta
+print(f"torch.get_num_threads: {torch.get_num_threads()}", flush=True)
+warnings.filterwarnings("ignore")
+
+from roosts.system import RoostSystem
+from roosts.utils.time_util import get_days_list, get_sun_activity_time
+from roosts.utils.s3_util import get_station_day_scan_keys
+from yacs.config import CfgNode as CN
+
+here = os.path.dirname(os.path.realpath(__file__))
+
+def run_system():
+  args = CN()
+  args.station = station
+  args.start = start
+  args.end = end
+  args.sun_activity = sun_activity
+  args.min_before = min_before
+  args.min_after = min_after
+  args.data_root = "inference_results"
+  args.just_render = False
+  args.gif_vis = True
+  args.aws_access_key_id=aws_access_key_id
+  args.aws_secret_access_key=aws_secret_access_key
+
+  # detection model config
+  DET_CFG = {
+      "ckpt_path": f"{here}/../checkpoints/v3.pth",
+      "imsize": 1200,
+      "anchor_sizes": [[16, 18, 20, 22, 24, 26, 28, 30, 32],
+              [32, 36, 40, 44, 48, 52, 56, 60, 64],
+              [64, 72, 80, 88, 96, 104, 112, 120, 128],
+              [128, 144, 160, 176, 192, 208, 224, 240, 256],
+              [256, 288, 320, 352, 384, 416, 448, 480, 512]],
+      "nms_thresh": 0.3,
+      "score_thresh": 0.1,
+      "config_file": "COCO-Detection/faster_rcnn_R_101_FPN_3x.yaml",
+      "use_gpu": torch.cuda.is_available(),
+      "version": "v3"
+  }
+
+  # postprocessing config
+  PP_CFG = {
+      "imsize": 600,
+      "geosize": 300000,
+      "sun_activity": args.sun_activity,
+      "clean_windfarm": True,
+      "clean_rain": True
+  }
+
+  # directories
+  DIRS = {
+      "scan_dir": os.path.join(args.data_root, 'scans'),  # raw scans downloaded from AWS or Azure
+      "npz_dir": os.path.join(args.data_root, 'arrays'), # rendered npz file
+      "log_root_dir": os.path.join(args.data_root, 'logs'),
+      "vis_det_dir": os.path.join(args.data_root, 'vis_dets'), # vis of detections from detection model
+      "vis_NMS_MERGE_track_dir": os.path.join(args.data_root, 'vis_NMS_MERGE_tracks'), # vis of tracks after NMS & merge
+      "ui_img_dir": os.path.join(args.data_root, 'ui', 'img'),
+      "scan_and_track_dir": os.path.join(args.data_root, 'ui', "scans_and_tracks"),
+  }
+
+  days = get_days_list(args.start, args.end)
+  print("Total number of days: %d" % len(days), flush=True)
+
+  roost_system = RoostSystem(args, DET_CFG, PP_CFG, DIRS)
+  for day_idx, day in enumerate(days):
+      process_start_time = time.time()
+
+      date_string = day.strftime('%Y%m%d')  # yyyymmdd
+      print(f"-------------------- Day {day_idx+1}: {date_string} --------------------\n", flush=True)
+
+      sun_activity_time = get_sun_activity_time(args.station, day, sun_activity=args.sun_activity) # utc
+      start_time = sun_activity_time - timedelta(minutes=args.min_before)
+      end_time = sun_activity_time + timedelta(minutes=args.min_after)
+      keys = get_station_day_scan_keys(start_time, end_time, args.station,
+                        aws_access_key_id=args.aws_access_key_id,
+                        aws_secret_access_key=args.aws_secret_access_key)
+      keys = sorted(list(set(keys)))  # aws keys
+
+      roost_system.run_day_station(day, sun_activity_time, keys, process_start_time)
+
+station = "KTYX" # a single station name, eg. KDOX
+start = "20200812" # the first day to process
+end = "20200812" # the last day to process
+sun_activity = "sunrise" # process scans in a time window around "sunrise" or "sunset"
+min_before = 30 # process scans this many minutes before the sun activity
+min_after = 60 # process scans this many minutes after the sun activity
+
+aws_access_key_id = None
+aws_secret_access_key = None
+run_system()

--- a/tools/launch_demo_without_slurm_canadian.py
+++ b/tools/launch_demo_without_slurm_canadian.py
@@ -1,0 +1,87 @@
+import time, os, torch, warnings
+from datetime import timedelta
+print(f"torch.get_num_threads: {torch.get_num_threads()}", flush=True)
+warnings.filterwarnings("ignore")
+
+from roosts.system import RoostSystem
+from roosts.utils.time_util import get_days_list, get_sun_activity_time
+from roosts.utils.azure_sa_util import get_station_day_scan_keys
+from yacs.config import CfgNode as CN
+
+here = os.path.dirname(os.path.realpath(__file__))
+
+def run_system():
+  args = CN()
+  args.station = station
+  args.start = start
+  args.end = end
+  args.sun_activity = sun_activity
+  args.min_before = min_before
+  args.min_after = min_after
+  args.data_root = "inference_results"
+  args.just_render = False
+  args.gif_vis = True
+  args.is_canadian = True
+
+  # detection model config
+  DET_CFG = {
+      "ckpt_path": f"{here}/../checkpoints/v3.pth",
+      "imsize": 1200,
+      "anchor_sizes": [[16, 18, 20, 22, 24, 26, 28, 30, 32],
+              [32, 36, 40, 44, 48, 52, 56, 60, 64],
+              [64, 72, 80, 88, 96, 104, 112, 120, 128],
+              [128, 144, 160, 176, 192, 208, 224, 240, 256],
+              [256, 288, 320, 352, 384, 416, 448, 480, 512]],
+      "nms_thresh": 0.3,
+      "score_thresh": 0.1,
+      "config_file": "COCO-Detection/faster_rcnn_R_101_FPN_3x.yaml",
+      "use_gpu": torch.cuda.is_available(),
+      "version": "v3"
+  }
+
+  # postprocessing config
+  PP_CFG = {
+      "imsize": 600,
+      "geosize": 300000,
+      "sun_activity": args.sun_activity,
+      "clean_windfarm": True,
+      "clean_rain": True
+  }
+
+  # directories
+  DIRS = {
+      "scan_dir": os.path.join(args.data_root, 'scans'),  # raw scans downloaded from AWS or Azure
+      "npz_dir": os.path.join(args.data_root, 'arrays'), # rendered npz file
+      "log_root_dir": os.path.join(args.data_root, 'logs'),
+      "vis_det_dir": os.path.join(args.data_root, 'vis_dets'), # vis of detections from detection model
+      "vis_NMS_MERGE_track_dir": os.path.join(args.data_root, 'vis_NMS_MERGE_tracks'), # vis of tracks after NMS & merge
+      "ui_img_dir": os.path.join(args.data_root, 'ui', 'img'),
+      "scan_and_track_dir": os.path.join(args.data_root, 'ui', "scans_and_tracks"),
+  }
+
+  days = get_days_list(args.start, args.end)
+  print("Total number of days: %d" % len(days), flush=True)
+
+  roost_system = RoostSystem(args, DET_CFG, PP_CFG, DIRS)
+  for day_idx, day in enumerate(days):
+      process_start_time = time.time()
+
+      date_string = day.strftime('%Y%m%d')  # yyyymmdd
+      print(f"-------------------- Day {day_idx+1}: {date_string} --------------------\n", flush=True)
+
+      sun_activity_time = get_sun_activity_time(args.station, day, sun_activity=args.sun_activity) # utc
+      start_time = sun_activity_time - timedelta(minutes=args.min_before)
+      end_time = sun_activity_time + timedelta(minutes=args.min_after)
+      keys = get_station_day_scan_keys(start_time, end_time, args.station)
+      keys = sorted(list(set(keys)))  # azure keys
+
+      roost_system.run_day_station(day, sun_activity_time, keys, process_start_time)
+
+station = "CSET" # a single station name, eg. KDOX. 4 letter short form for CASET = CSET
+# We needed station code to be 4 letter to work with minimal changes to code for American data
+start = "20220601" # the first day to process
+end = "20220602" # the last day to process
+sun_activity = "sunrise" # process scans in a time window around "sunrise" or "sunset"
+min_before = 30 # process scans this many minutes before the sun activity
+min_after = 60 # process scans this many minutes after the sun activity
+run_system()


### PR DESCRIPTION
**Storage Account:**

**Done:** 
Uploaded June 2022 data to a container (having public access) using Azcopy with some exceptions

**Todo:**
1. Check log file and re-upload files that threw exceptions for June 2022.
2. Narrow down access to SA (to reduce cost incurred upon us for read, and allowing no write) - Perhaps add access policies (need to discuss).
3. Add Jul-Sep 2022 data to the container.

<br/>

**Code changes**

**Done:**
1. Added _inference_results_ (default results folder) to _.gitignore_, since we don't want the results to be pushed.
2. Added _azure-storage-blob_ (to facilitate interaction with Canadian radar data uploaded to Azure storage account container) and _h5py_ (to read radar data from _hdf5_ files) packages to _setup.py_.
4. Created a superclass _Downloader_ with abstract method _download_scans_ that serves as template to two subclasses - _DownloaderAmerica_ and _DownLoaderCanada_ that facilitate download of scans from AWS and Azure respectively.
5. In _renderer.py_, ensured that radar is rendered using _read_odim_h5_ method for Canadian data, with specified ODIM_FIELD_NAMES.
6. In _system.py_, ensured that the _Downloader_ and _Renderer_ used for American/Canadian data are instantiated using the correct subclass or are passed the correct parameters.
7. Created an additional util (_azure_sa_util.py_) to interact with Azure storage account container, which contains the Canadian radar scans.
8. Updated _nexrad_util.py_ to include data for the new radar station (CASET) for Canadian radar data.
9. Added file _launch_demo_without_slurm_america.py_ for test run of American radar data locally. Added file _launch_demo_without_slurm_canada.py_ for test run of Canadian radar data locally. Both the files use a different instance of _get_station_day_scan_keys_ based on key names for American/Canadian data.


**Todo**:
1. Make changes to ensure that we need Azure credentials too (currently the container is open access).